### PR TITLE
Update tools/carwhisperer-0.2/Makefile

### DIFF
--- a/tools/carwhisperer-0.2/Makefile
+++ b/tools/carwhisperer-0.2/Makefile
@@ -21,5 +21,5 @@ install:
 uninstall:
 	rm /usr/bin/carwhisperer
 	mv /etc/bluetooth/hcid.conf.old /etc/bluetooth/hcid.conf
-	rm /usr/bin/cw_pin.sh 
+	rm /usr/bin/cw_pin.pl 
 	rm /usr/bin/cw_scanner 


### PR DESCRIPTION
Changed the wrong file extension of the "rm /usr/bin/cw_pin.sh" to "rm /usr/bin/cw_pin.pl", which already was corrected in the install section, but not yet in the uninstall part.
